### PR TITLE
fix: parse dashboard won't allow login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "parse-hipaa-dashboard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "parse-dashboard": "^4.1.3"
+        "parse-dashboard": "^4.1.4"
       },
       "devDependencies": {
         "@babel/cli": "7.17.0",
@@ -6983,9 +6983,9 @@
       }
     },
     "node_modules/parse-dashboard": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/parse-dashboard/-/parse-dashboard-4.1.3.tgz",
-      "integrity": "sha512-eKoeJRuqCtp0RxmDtmzz8S5I2lUYwZXNkCUwrgnteWtXsce6V/xvvJQJrfyd5dHG1yel06WulkISo+uaENjpvA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/parse-dashboard/-/parse-dashboard-4.1.4.tgz",
+      "integrity": "sha512-E8mCf80BuKvD/k1T/8yp+VlojrqOn2b7SzRMusSui/6+HkSqa7oduFuwg6dPTzI+keaiG9tup9EaaorZtONukg==",
       "dependencies": {
         "@babel/runtime": "7.18.3",
         "bcryptjs": "2.3.0",
@@ -7007,7 +7007,7 @@
         "otpauth": "7.1.3",
         "package-json": "7.0.0",
         "parse": "3.4.2",
-        "passport": "0.6.0",
+        "passport": "0.5.3",
         "passport-local": "1.0.0",
         "prismjs": "1.28.0",
         "prop-types": "15.8.1",
@@ -7075,13 +7075,12 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"
@@ -14254,9 +14253,9 @@
       }
     },
     "parse-dashboard": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/parse-dashboard/-/parse-dashboard-4.1.3.tgz",
-      "integrity": "sha512-eKoeJRuqCtp0RxmDtmzz8S5I2lUYwZXNkCUwrgnteWtXsce6V/xvvJQJrfyd5dHG1yel06WulkISo+uaENjpvA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/parse-dashboard/-/parse-dashboard-4.1.4.tgz",
+      "integrity": "sha512-E8mCf80BuKvD/k1T/8yp+VlojrqOn2b7SzRMusSui/6+HkSqa7oduFuwg6dPTzI+keaiG9tup9EaaorZtONukg==",
       "requires": {
         "@babel/runtime": "7.18.3",
         "bcryptjs": "2.3.0",
@@ -14278,7 +14277,7 @@
         "otpauth": "7.1.3",
         "package-json": "7.0.0",
         "parse": "3.4.2",
-        "passport": "0.6.0",
+        "passport": "0.5.3",
         "passport-local": "1.0.0",
         "prismjs": "1.28.0",
         "prop-types": "15.8.1",
@@ -14318,13 +14317,12 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "requires": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       }
     },
     "passport-local": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-hipaa-dashboard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The Parse-HIPAA Dashboard.",
   "main": "./lib/index.js",
   "repository": {
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "parse-dashboard": "^4.1.3"
+    "parse-dashboard": "^4.1.4"
   },
   "devDependencies": {
     "@babel/cli": "7.17.0",


### PR DESCRIPTION
Parse dashboard had an issue with a dependency on passport which won't allow login